### PR TITLE
[12.0][UPD] Lock number is required when value_type = 'Rent'

### DIFF
--- a/acm/acm_agreement_contract/views/product_views.xml
+++ b/acm/acm_agreement_contract/views/product_views.xml
@@ -67,7 +67,7 @@
                             <field name="lock_attribute"/>
                             <field name="group_id" attrs="{'required': [('value_type', '=', 'rent')]}"/>
                             <field name="subzone"/>
-                            <field name="lock_number"/>
+                            <field name="lock_number" attrs="{'required': [('value_type', '=', 'rent')]}"/>
                         </group>
                     </group>
                 </page>


### PR DESCRIPTION
![Selection_734](https://user-images.githubusercontent.com/24691983/73329213-4a264500-428f-11ea-99d6-c80abfd21147.png)
