### PR TITLE
[12.0][UPD] Add Invoice Date (Days)

### DIFF
--- a/acm/acm_agreement_contract/models/res_company.py
+++ b/acm/acm_agreement_contract/models/res_company.py
@@ -12,3 +12,8 @@ class ResCompany(models.Model):
     market_address = fields.Char()
     fax = fields.Char()
     company_phone = fields.Char()
+    show_invoice_date = fields.Boolean(
+        string="Show Invoice Date (Days) ?",
+        default=False,
+        help="When you click this, the system will Show Invoice Date (Days) on the agreement if repeat every only 'Month(s)'"
+    )

--- a/acm/acm_agreement_contract/views/agreement_views.xml
+++ b/acm/acm_agreement_contract/views/agreement_views.xml
@@ -45,6 +45,8 @@
                     <field name="recurring_interval" class="oe_inline"/>
                     <field name="recurring_rule_type" class="oe_inline"/>
                 </div>
+                <field name="show_invoice_date" invisible="1"/>
+                <field name="invoice_date_days" attrs="{'invisible': ['|', '|', ('show_invoice_date', '!=', True), ('is_template', '=', True), ('recurring_rule_type', '!=', 'monthly')], 'required': [('show_invoice_date', '=', True), ('is_template', '=', False), ('recurring_rule_type', '=', 'monthly')]}"/>
             </field>
             <field name="termination_date" position="attributes">
                 <attribute name="readonly">True</attribute>

--- a/acm/acm_agreement_contract/views/res_company_views.xml
+++ b/acm/acm_agreement_contract/views/res_company_views.xml
@@ -14,6 +14,9 @@
                             <field name="market_address"/>
                             <field name="company_phone" string="Phone"/>
                         </group>
+                        <group>
+                            <field name="show_invoice_date"/>
+                        </group>
                     </group>
                 </page>
             </notebook>


### PR DESCRIPTION
This PR add some feature
- Invoice Date (Days) on the agreement. (Date of Next Invoice on the customer contract will equal to this one)

### Test Case
**Case 1 : no check show invoice date (days) on the company**
- date of next invoice will be start date

**Case 2 : check show invoice date (days) on the company**
- Case 2.1 Invoice Date (Days) >= Start Date
  - ถ้า invoice date (days) มากกว่าวันสุดท้ายของเดือน ให้แสดง error "Invoice Date (Days) greater than last day of mm/yyyy"
  - ถ้าไม่ใช่ข้างบนก็ให้บันทึก Date of Next Invoice เป็น วันที่เดียวกับ Invoice Date (Days)
- Case 2.2 Invoice Date (Days) < Start Date
  - ถ้า invoice date (days) มากกว่าวันสุดท้ายของเดือนถัดไป ให้แสดง error "Invoice Date (Days) greater than last day of mm/yyyy"
  - ถ้าไม่ใช่ข้างบนก็ให้บันทึก Date of Next Invoice เป็น วันที่เดียวกับ Invoice Date (Days) แต่เป็นเดือนถัดไป

@Cncd10 Is this make sense ?