### PR TITLE
[FIX] acm_agreement_contract: No filter lastest version rental product on agreement

### DIFF
--- a/acm/acm_agreement_contract/views/agreement_views.xml
+++ b/acm/acm_agreement_contract/views/agreement_views.xml
@@ -62,7 +62,7 @@
             <group name="term_information" position="inside">
                 <group string="Rental Information">
                     <field name="year_start_date" invisible="1"/>
-                    <field name="rent_product_id" domain="[('year', '=', year_start_date), ('is_lastest_version', '=', True)]" attrs="{'invisible': [('is_template', '=', True)], 'readonly': [('state', '=', 'active'), ('is_template', '=', False)]}"/>
+                    <field name="rent_product_id" domain="[('year', '=', year_start_date)]" attrs="{'invisible': [('is_template', '=', True)], 'readonly': [('state', '=', 'active'), ('is_template', '=', False)]}"/>
                 </group>
             </group>
             <field name="termination_date" position="attributes">

--- a/acm_odoo_lite/models/agreement.py
+++ b/acm_odoo_lite/models/agreement.py
@@ -217,6 +217,11 @@ class Agreement(models.Model):
     def _validate_rent_product_dates(self, product_lines):
         return True
 
+
+    @api.multi
+    def _validate_rent_product_year(self):
+        return True
+
     @api.constrains("line_ids")
     def _check_line_ids(self):
         return


### PR DESCRIPTION
- แก้ไขให้ Rental product กรองตามปีที่สร้างสัญญา
- ตรวจสอบว่าปีที่สร้าง Rental product ตรงกับปีที่สร้างสัญญา
- ตรวจสอบว่า Rental product เป็น version ล่าสุด ณ ปีที่สร้างสัญญา
 
![Selection_026](https://github.com/user-attachments/assets/0b8d3a7d-cf71-4772-950e-09c2becb61d4)
